### PR TITLE
update circe 0.11, update scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "com.chatwork"
 
 name := "scala-jwk"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.11.11", "2.12.6")
+crossScalaVersions := Seq("2.11.11", "2.12.8")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -34,7 +34,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   ScalaTest.v3_0_1      % Test,
   ScalaCheck.scalaCheck % Test,
-  Cats.v1_1_0,
+  Cats.v1_6_1,
   Enumeratum.latest,
   Scala.java8Compat,
   J5ik2o.base64scala,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Scala {
 }
 
 object Circe {
-  val version           = "0.10.0"
+  val version           = "0.11.1"
   val core: ModuleID    = "io.circe" %% "circe-core" % version
   val parser: ModuleID  = "io.circe" %% "circe-parser" % version
   val generic: ModuleID = "io.circe" %% "circe-generic" % version
@@ -17,11 +17,11 @@ object ScalaTest {
 }
 
 object Cats {
-  val v1_1_0="org.typelevel"         %% "cats-core"            % "1.1.0"
+  val v1_6_1 ="org.typelevel"         %% "cats-core"            % "1.6.1"
 }
 
 object Enumeratum {
-  val latest = "com.beachape" %% "enumeratum" % "1.5.12"
+  val latest = "com.beachape" %% "enumeratum" % "1.5.13"
 }
 
 object ScalaCheck {
@@ -29,5 +29,5 @@ object ScalaCheck {
 }
 
 object J5ik2o {
-  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.4"
+  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.4" excludeAll ExclusionRule(organization = "io.circe")
 }


### PR DESCRIPTION
Hello!
I have excluded transitive circe `0.10` from `base64scala`. According to my short research circe could be removed altogether from that library too, which would make that strange `ExclusionRule` unnecessary.