### PR TITLE
added support for RSA-OAEP as optional alg

### DIFF
--- a/src/main/scala/com/chatwork/scala/jwk/JWSAlgorithmType.scala
+++ b/src/main/scala/com/chatwork/scala/jwk/JWSAlgorithmType.scala
@@ -16,9 +16,10 @@ object JWSAlgorithmType extends AlgorithmTypeFactory[JWSAlgorithmType] {
   case object HS384 extends JWSAlgorithmType("HS384", Requirement.Optional)
   case object HS512 extends JWSAlgorithmType("HS512", Requirement.Optional)
 
-  case object RS256 extends JWSAlgorithmType("RS256", Requirement.Recommended)
-  case object RS384 extends JWSAlgorithmType("RS384", Requirement.Optional)
-  case object RS512 extends JWSAlgorithmType("RS512", Requirement.Optional)
+  case object RS256   extends JWSAlgorithmType("RS256", Requirement.Recommended)
+  case object RS384   extends JWSAlgorithmType("RS384", Requirement.Optional)
+  case object RS512   extends JWSAlgorithmType("RS512", Requirement.Optional)
+  case object RSAOAEP extends JWSAlgorithmType("RSA-OAEP", Requirement.Optional)
 
   case object ES256 extends JWSAlgorithmType("ES256", Requirement.Recommended)
   case object ES384 extends JWSAlgorithmType("ES384", Requirement.Optional)
@@ -38,7 +39,7 @@ object JWSAlgorithmType extends AlgorithmTypeFactory[JWSAlgorithmType] {
       override val values: Set[JWSAlgorithmType] = Set(HS256, HS384, HS512)
     }
     case object RSA extends AlgorithmFamily {
-      override val values: Set[JWSAlgorithmType] = Set(RS256, RS384, RS512, PS256, PS384, PS512)
+      override val values: Set[JWSAlgorithmType] = Set(RS256, RS384, RS512, PS256, PS384, PS512, RSAOAEP)
     }
     case object EC extends AlgorithmFamily {
       override val values: Set[JWSAlgorithmType] = Set(ES256, ES384, ES512)


### PR DESCRIPTION
I've got an error for a missing algorithm while testing with a OpenID Connect supplier (signicat).

Here is the jwks json: https://preprod.signicat.com/oidc/jwks.json

Here is the error:

```
[error] (run-main-0) zio.FiberFailure: Fiber failed.
[error] An unchecked error was produced.
[error] java.util.NoSuchElementException: RSA-OAEP is not a member of Enum (HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512)
[error] 	at enumeratum.Enum.$anonfun$withName$1(Enum.scala:81)
[error] 	at scala.Option.getOrElse(Option.scala:201)
[error] 	at enumeratum.Enum.withName(Enum.scala:81)
[error] 	at enumeratum.Enum.withName$(Enum.scala:80)
[error] 	at com.chatwork.scala.jwk.JWSAlgorithmType$.withName(JWSAlgorithmType.scala:11)
[error] 	at com.chatwork.scala.jwk.JWSAlgorithmTypeJsonImplicits.$anonfun$jWSAlgorithmTypeJsonDecoder$1(JWSAlgorithmType.scala:53)
[error] 	at io.circe.Decoder$$anon$1.tryDecode(Decoder.scala:97)
[error] 	at io.circe.Decoder$$anon$1.apply(Decoder.scala:95)
[error] 	at io.circe.Decoder$$anon$39.tryDecode(Decoder.scala:938)
[error] 	at io.circe.Decoder$$anon$39.apply(Decoder.scala:932)
[error] 	at io.circe.Decoder$$anon$39.tryDecode(Decoder.scala:938)
[error] 	at io.circe.ACursor.as(ACursor.scala:218)
[error] 	at io.circe.ACursor.get(ACursor.scala:225)
[error] 	at io.circe.ACursor.getOrElse(ACursor.scala:234)
[error] 	at com.chatwork.scala.jwk.RSAJWKJsonImplicits.$anonfun$RSAJWKJsonDecoder$7(RSAJWK.scala:639)
[error] 	at scala.util.Either.flatMap(Either.scala:352)
[error] 	at com.chatwork.scala.jwk.RSAJWKJsonImplicits.$anonfun$RSAJWKJsonDecoder$5(RSAJWK.scala:638)
[error] 	at scala.util.Either.flatMap(Either.scala:352)
[error] 	at com.chatwork.scala.jwk.RSAJWKJsonImplicits.$anonfun$RSAJWKJsonDecoder$4(RSAJWK.scala:637)
[error] 	at scala.util.Either.flatMap(Either.scala:352)
[error] 	at com.chatwork.scala.jwk.RSAJWKJsonImplicits.$anonfun$RSAJWKJsonDecoder$1(RSAJWK.scala:634)
[error] 	at io.circe.Decoder$$anon$16.apply(Decoder.scala:501)
[error] 	at com.chatwork.scala.jwk.JWKJsonImplicits.$anonfun$JWKJsonDecoder$2(JWK.scala:106)
[error] 	at scala.util.Either.flatMap(Either.scala:352)
[error] 	at com.chatwork.scala.jwk.JWKJsonImplicits.$anonfun$JWKJsonDecoder$1(JWK.scala:104)
[error] 	at io.circe.Decoder$$anon$16.apply(Decoder.scala:501)
[error] 	at io.circe.SeqDecoder.apply(SeqDecoder.scala:17)
[error] 	at io.circe.Decoder.tryDecode(Decoder.scala:68)
[error] 	at io.circe.Decoder.tryDecode$(Decoder.scala:67)
[error] 	at io.circe.SeqDecoder.tryDecode(SeqDecoder.scala:6)
[error] 	at io.circe.ACursor.as(ACursor.scala:218)
[error] 	at io.circe.ACursor.get(ACursor.scala:225)
[error] 	at com.chatwork.scala.jwk.JWKSetJsonImplicits.$anonfun$JWKSetJsonDecoder$1(JWKSet.scala:77)
[error] 	at io.circe.Decoder$$anon$16.apply(Decoder.scala:501)
[error] 	at io.circe.Decoder.decodeJson(Decoder.scala:86)
[error] 	at io.circe.Decoder.decodeJson$(Decoder.scala:86)
[error] 	at io.circe.Decoder$$anon$16.decodeJson(Decoder.scala:500)
[error] 	at org.http4s.circe.CirceInstances.$anonfun$jsonOfWithMediaHelper$1(CirceInstances.scala:104)
[error] 	at cats.data.EitherT.$anonfun$flatMap$1(EitherT.scala:391)
[error] 	at zio.internal.FiberContext.evaluateNow(FiberContext.scala:914)
[error] 	at zio.internal.FiberContext.$anonfun$evaluateLater$1(FiberContext.scala:776)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error]
[error] Fiber:Id(1611766116729,1) was supposed to continue to:
[error]   a future continuation at cats.MonadError.rethrow(MonadError.scala:40)
[error]   a future continuation at zio.ZIO.run(ZIO.scala:1646)
[error]   a future continuation at zio.interop.CatsConcurrent.bracketCase(cats.scala:268)
[error]   a future continuation at zio.ZIO.run(ZIO.scala:1646)
[error]   a future continuation at zio.ZManaged.use(ZManaged.scala:1025)
[error]   a future continuation at com.rocker.authprovider.http.HttpClient$Http4s.getRequest(HttpClient.scala:44)
[error]   a future continuation at com.rocker.authprovider.web.App$.getJWKSet(App.scala:45)
[error]   a future continuation at zio.ZIO.run(ZIO.scala:1646)
[error]   a future continuation at zio.ZIO.bracket_(ZIO.scala:256)
[error]   a future continuation at zio.ZIO.run(ZIO.scala:1646)
[error]   a future continuation at zio.ZManaged.use(ZManaged.scala:1025)
[error]   a future continuation at com.rocker.authprovider.web.App$.run(App.scala:118)
[error]
[error] Fiber:Id(1611766116729,1) execution trace:
[error]   at cats.data.EitherT.flatMap(EitherT.scala:389)
[error]   at cats.data.EitherT.subflatMap(EitherT.scala:401)
[error]   at org.http4s.DecodeResult$.success(DecodeResult.scala:28)
[error]   at org.http4s.EntityDecoder$.collectBinary(EntityDecoder.scala:192)
[error]   at fs2.Stream$CompileOps.to_(Stream.scala:4464)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:159)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:152)
[error]   at zio.ZIO$.effectSuspendTotal(ZIO.scala:2648)
[error]   at zio.ZIO$.bracketExit(ZIO.scala:2279)
[error]   at zio.ZIO.orDieWith(ZIO.scala:1048)
[error]   at cats.syntax.MonadErrorRethrowOps$.rethrow(monadError.scala:43)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:247)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:246)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:245)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:243)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:242)
[error]   at cats.effect.concurrent.Ref$SyncRef.modify(Ref.scala:320)
[error]   at zio.interop.CatsConcurrent.bracketCase(cats.scala:268)
[error]   at zio.ZIO.run(ZIO.scala:1646)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:152)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:595)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:546)
[error]   at fs2.internal.CompileScope.openAncestor(CompileScope.scala:262)
[error]   at cats.effect.concurrent.Ref$SyncRef.get(Ref.scala:257)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:545)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:247)
[error]   at cats.effect.concurrent.Ref$SyncRef.update(Ref.scala:298)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:246)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:245)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:243)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:242)
[error]   at cats.effect.concurrent.Ref$SyncRef.modify(Ref.scala:320)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:568)
[error]   at cats.syntax.ApplicativeErrorOps$.orElse(applicativeError.scala:77)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:436)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:463)
[error]   at zio.ZIO$.zio$ZIO$$_succeedRight(ZIO.scala:4152)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:546)
[error]   at fs2.internal.CompileScope.openAncestor(CompileScope.scala:262)
[error]   at cats.effect.concurrent.Ref$SyncRef.get(Ref.scala:257)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:545)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:247)
[error]   at cats.effect.concurrent.Ref$SyncRef.update(Ref.scala:298)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:246)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:245)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:243)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:242)
[error]   at cats.effect.concurrent.Ref$SyncRef.modify(Ref.scala:320)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:568)
[error]   at cats.syntax.ApplicativeErrorOps$.orElse(applicativeError.scala:77)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:546)
[error]   at fs2.internal.CompileScope.openAncestor(CompileScope.scala:262)
[error]   at cats.effect.concurrent.Ref$SyncRef.get(Ref.scala:257)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:545)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:247)
[error]   at cats.effect.concurrent.Ref$SyncRef.update(Ref.scala:298)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:246)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:245)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at cats.data.Chain$.traverseViaChain(Chain.scala:711)
[error]   at cats.data.Chain$.traverseViaChain(Chain.scala:702)
[error]   at zio.ZIO$.zio$ZIO$$_succeedRight(ZIO.scala:4152)
[error]   at zio.ZIO.unit(ZIO.scala:2000)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:159)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:152)
[error]   at zio.ZIO.onInterrupt(ZIO.scala:981)
[error]   at zio.internal.FiberContext$InterruptExit$.apply(FiberContext.scala:152)
[error]   at zio.ZIO$.effectSuspendTotal(ZIO.scala:2648)
[error]   at zio.ZIO$._IdentityFn(ZIO.scala:3973)
[error]   at zio.internal.FiberContext.await(FiberContext.scala:785)
[error]   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2582)
[error]   at zio.ZIO$.effectAsyncInterrupt(ZIO.scala:2582)
[error]   at zio.ZIO$.effectSuspendTotal(ZIO.scala:2648)
[error]   at zio.Fiber.interrupt(Fiber.scala:144)
[error]   at zio.ZIO$.fiberId(ZIO.scala:2699)
[error]   at zio.ZIO$.descriptor(ZIO.scala:2489)
[error]   at zio.ZIO$.effectSuspend(ZIO.scala:2639)
[error]   at fs2.internal.ScopedResource$$anon$1.release(ScopedResource.scala:136)
[error]   at cats.effect.concurrent.Ref$SyncRef.modify(Ref.scala:320)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:243)
[error]   at fs2.internal.CompileScope.traverseError(CompileScope.scala:223)
[error]   at fs2.internal.CompileScope.close(CompileScope.scala:242)
[error]   at cats.effect.concurrent.Ref$SyncRef.modify(Ref.scala:320)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:568)
[error]   at cats.syntax.ApplicativeErrorOps$.orElse(applicativeError.scala:77)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:460)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:595)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:436)
[error]   at cats.effect.concurrent.Ref$SyncRef.get(Ref.scala:257)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:436)
[error]   at cats.effect.concurrent.Ref$SyncRef.get(Ref.scala:257)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:463)
[error]   at zio.ZIO$.zio$ZIO$$_succeedRight(ZIO.scala:4152)
[error]   at fs2.internal.FreeC$.compile(Algebra.scala:436)
[error]
```