### PR TITLE
Bump Scala: 2.13.4 is interoperable with Scala 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
           key: scala-library-dependencies-{{ checksum "build.sbt" }}-{{ checksum "project/Dependencies.scala" }}
       - run:
           command: |
-            sbt clean ++"2.12.10" scalafmtCheckAll scalafmtSbtCheck test
-            sbt clean ++"2.13.1" scalafmtCheckAll scalafmtSbtCheck test
+            sbt clean ++"2.12.13" scalafmtCheckAll scalafmtSbtCheck test
+            sbt clean ++"2.13.4" scalafmtCheckAll scalafmtSbtCheck test
           no_output_timeout: 1h
       - save_cache:
           paths: [ "~/.sbt/boot", "~/.m2", "~/.ivy2", "~/.cache/coursier", "~/.wixMySQL" ]

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-val scala212Version = "2.12.10"
-val scala213Version = "2.13.1"
+val scala212Version = "2.12.13"
+val scala213Version = "2.13.4"
 
 sonatypeProfileName := "com.chatwork"
 


### PR DESCRIPTION
Scala 2.13.4 is interoperable with Scala 3.
Scala 3 can consume the libraries published for Scala 2.13.4+.
