### PR TITLE
Add cross build for Scala 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             sbt clean ++"2.12.13" scalafmtCheckAll scalafmtSbtCheck test
             sbt clean ++"2.13.6" scalafmtCheckAll scalafmtSbtCheck test
-            sbt clean ++"3.0.0" scalafmtCheckAll scalafmtSbtCheck test
+            sbt clean ++"3.0.1" scalafmtCheckAll scalafmtSbtCheck test
           no_output_timeout: 1h
       - save_cache:
           paths: [ "~/.sbt/boot", "~/.m2", "~/.ivy2", "~/.cache/coursier", "~/.wixMySQL" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
       - run:
           command: |
             sbt clean ++"2.12.13" scalafmtCheckAll scalafmtSbtCheck test
-            sbt clean ++"2.13.4" scalafmtCheckAll scalafmtSbtCheck test
+            sbt clean ++"2.13.6" scalafmtCheckAll scalafmtSbtCheck test
+            sbt clean ++"3.0.0" scalafmtCheckAll scalafmtSbtCheck test
           no_output_timeout: 1h
       - save_cache:
           paths: [ "~/.sbt/boot", "~/.m2", "~/.ivy2", "~/.cache/coursier", "~/.wixMySQL" ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Scala library supports JWKSet(RFC7517).
 
 ## Installation
 
-Add the following to your sbt build (2.12.x, 2.13.x):
+Add the following to your sbt build (2.12.x, 2.13.x, 3.0.x):
 
 ### Release Version
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val scala212Version = "2.12.13"
 val scala213Version = "2.13.6"
-val scala3Version = "3.0.0"
+val scala3Version   = "3.0.1"
 
 sonatypeProfileName := "com.chatwork"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 val scala212Version = "2.12.13"
-val scala213Version = "2.13.4"
+val scala213Version = "2.13.6"
+val scala3Version = "3.0.0"
 
 sonatypeProfileName := "com.chatwork"
 
@@ -9,7 +10,7 @@ name := "scala-jwk"
 
 scalaVersion := scala213Version
 
-crossScalaVersions := Seq(scala212Version, scala213Version)
+crossScalaVersions := Seq(scala212Version, scala213Version, scala3Version)
 
 scalacOptions ++= Seq(
   "-feature",
@@ -22,6 +23,8 @@ scalacOptions ++= Seq(
 
 scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3L, _)) =>
+      Seq.empty
     case Some((2L, scalaMajor)) if scalaMajor >= 12 =>
       Seq.empty
     case Some((2L, scalaMajor)) if scalaMajor <= 11 =>
@@ -39,7 +42,6 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   scalatest.scalatest   % Test,
   scalacheck.scalacheck % Test,
-  beachape.enumeratum,
   scalaLang.java8Compat,
   j5ik2o.base64scala,
   circe.core,
@@ -49,13 +51,13 @@ libraryDependencies ++= Seq(
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
-parallelExecution in Test := false
+Test / parallelExecution := false
 
-javaOptions in (Test, run) ++= Seq("-Xms4g", "-Xmx4g", "-Xss10M", "-XX:+CMSClassUnloadingEnabled")
+Test / run / javaOptions ++= Seq("-Xms4g", "-Xmx4g", "-Xss10M", "-XX:+CMSClassUnloadingEnabled")
 
 publishMavenStyle := true
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 
@@ -83,7 +85,7 @@ pomExtra := {
 publishTo := sonatypePublishToBundle.value
 
 credentials := {
-  val ivyCredentials = (baseDirectory in LocalRootProject).value / ".credentials"
-  val gpgCredentials = (baseDirectory in LocalRootProject).value / ".gpgCredentials"
+  val ivyCredentials = (LocalRootProject / baseDirectory).value / ".credentials"
+  val gpgCredentials = (LocalRootProject / baseDirectory).value / ".gpgCredentials"
   Credentials(ivyCredentials) :: Credentials(gpgCredentials) :: Nil
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,22 +2,18 @@ import sbt._
 import sbt.ModuleID
 
 object scalaLang {
-  val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
+  val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0"
 }
 
 object circe {
-  val version           = "0.13.0"
+  val version           = "0.14.1"
   val core: ModuleID    = "io.circe" %% "circe-core"    % version
   val parser: ModuleID  = "io.circe" %% "circe-parser"  % version
   val generic: ModuleID = "io.circe" %% "circe-generic" % version
 }
 
 object scalatest {
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.8"
-}
-
-object beachape {
-  val enumeratum = "com.beachape" %% "enumeratum" % "1.6.1"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.2.9"
 }
 
 object scalacheck {
@@ -25,5 +21,5 @@ object scalacheck {
 }
 
 object j5ik2o {
-  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.9"
+  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.14+1-592a8e04-SNAPSHOT"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,5 +21,5 @@ object scalacheck {
 }
 
 object j5ik2o {
-  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.14+1-592a8e04-SNAPSHOT"
+  val base64scala = "com.github.j5ik2o" %% "base64scala" % "1.0.21"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.0
+sbt.version = 1.5.2

--- a/src/main/scala/com/chatwork/scala/jwk/AlgorithmType.scala
+++ b/src/main/scala/com/chatwork/scala/jwk/AlgorithmType.scala
@@ -1,12 +1,11 @@
 package com.chatwork.scala.jwk
 
-import enumeratum._
-
-trait AlgorithmType extends EnumEntry {
+trait AlgorithmType extends Product with Serializable {
+  val entryName: String
   val requirement: Requirement
 }
 
-trait AlgorithmTypeFactory[A <: AlgorithmType] extends Enum[A] {
+trait AlgorithmTypeFactory[A <: AlgorithmType] {
 
   case object None extends AlgorithmType {
     override val entryName                = "none"

--- a/src/main/scala/com/chatwork/scala/jwk/KeyOperationType.scala
+++ b/src/main/scala/com/chatwork/scala/jwk/KeyOperationType.scala
@@ -1,14 +1,18 @@
 package com.chatwork.scala.jwk
 
-import enumeratum._
 import io.circe.{ Decoder, Encoder }
 
 import scala.collection.immutable
 
-sealed abstract class KeyOperationType(override val entryName: String) extends EnumEntry
+sealed abstract class KeyOperationType(val entryName: String) extends Product with Serializable
 
-object KeyOperationType extends Enum[KeyOperationType] {
-  override val values: immutable.IndexedSeq[KeyOperationType] = findValues
+object KeyOperationType {
+  val values: immutable.IndexedSeq[KeyOperationType] =
+    immutable.IndexedSeq(Sign, Verify, Encrypt, Decrypt, WrapKey, UnwrapKey, DeriveKey, DeriveBits)
+
+  def withNameEither(name: String): Either[String, KeyOperationType] =
+    values.find(_.entryName == name).toRight(s"Unknown key operation type $name")
+
   case object Sign       extends KeyOperationType("sign")
   case object Verify     extends KeyOperationType("verify")
   case object Encrypt    extends KeyOperationType("encrypt")
@@ -23,6 +27,7 @@ trait KeyOperationTypeJsonImplicits {
 
   implicit val publicKeyUseJsonEncoder: Encoder[KeyOperationType] = Encoder[String].contramap(_.entryName)
 
-  implicit val publicKeyUseJsonDecoder: Decoder[KeyOperationType] = Decoder[String].map(KeyOperationType.withName)
+  implicit val publicKeyUseJsonDecoder: Decoder[KeyOperationType] =
+    Decoder[String].emap(KeyOperationType.withNameEither)
 
 }

--- a/src/main/scala/com/chatwork/scala/jwk/PublicKeyUseType.scala
+++ b/src/main/scala/com/chatwork/scala/jwk/PublicKeyUseType.scala
@@ -1,15 +1,17 @@
 package com.chatwork.scala.jwk
 
-import enumeratum._
 import io.circe.{ Decoder, Encoder }
 
 import scala.collection.immutable
 
-sealed abstract class PublicKeyUseType(override val entryName: String) extends EnumEntry
+sealed abstract class PublicKeyUseType(val entryName: String) extends Product with Serializable
 
-object PublicKeyUseType extends Enum[PublicKeyUseType] {
+object PublicKeyUseType {
 
-  override val values: immutable.IndexedSeq[PublicKeyUseType] = findValues
+  val values: immutable.IndexedSeq[PublicKeyUseType] = immutable.IndexedSeq(Signature, Encryption)
+
+  def withNameEither(name: String): Either[String, PublicKeyUseType] =
+    values.find(_.entryName == name).toRight(s"Unknown public key use type $name")
 
   case object Signature  extends PublicKeyUseType("sig")
   case object Encryption extends PublicKeyUseType("enc")
@@ -19,6 +21,7 @@ trait PublicKeyUseJsonImplicits {
 
   implicit val PublicKeyUseJsonEncoder: Encoder[PublicKeyUseType] = Encoder[String].contramap(_.entryName)
 
-  implicit val PublicKeyUseJsonDecoder: Decoder[PublicKeyUseType] = Decoder[String].map(PublicKeyUseType.withName)
+  implicit val PublicKeyUseJsonDecoder: Decoder[PublicKeyUseType] =
+    Decoder[String].emap(PublicKeyUseType.withNameEither)
 
 }

--- a/src/main/scala/com/chatwork/scala/jwk/Requirement.scala
+++ b/src/main/scala/com/chatwork/scala/jwk/Requirement.scala
@@ -1,16 +1,15 @@
 package com.chatwork.scala.jwk
 
-import enumeratum._
-
 import scala.collection.immutable
 
-sealed trait Requirement extends EnumEntry
+sealed abstract class Requirement(val entryName: String) extends Product with Serializable
 
-object Requirement extends Enum[Requirement] {
-  override def values: immutable.IndexedSeq[Requirement] = findValues
+object Requirement {
+  def values: immutable.IndexedSeq[Requirement] =
+    immutable.IndexedSeq(Required, Recommended, Optional)
 
-  case object Required    extends Requirement
-  case object Recommended extends Requirement
-  case object Optional    extends Requirement
+  case object Required    extends Requirement("Required")
+  case object Recommended extends Requirement("Recommended")
+  case object Optional    extends Requirement("Optional")
 
 }


### PR DESCRIPTION
Updates dependencies and removes enumeratum as it won't cross build (any time soon). ~Depends on a local snapshot of base64scala until a new version is released ([PR for Scala 3 is open](https://github.com/j5ik2o/base64scala/pull/57))~ Updated to base64 1.0.21 with Scala 3 support.