### PR TITLE
Align x5c and thumbprint handling with RFC

### DIFF
--- a/library/src/main/scala/com/chatwork/scala/jwk/ECJWK.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/ECJWK.scala
@@ -1,11 +1,12 @@
 package com.chatwork.scala.jwk
 
+import cats.data.NonEmptyList
+
 import java.net.URI
 import java.security.interfaces.{ ECPrivateKey, ECPublicKey }
 import java.security.spec.{ ECPoint, ECPrivateKeySpec, ECPublicKeySpec, InvalidKeySpecException }
 import java.security.{ KeyFactory, NoSuchAlgorithmException, _ }
 import java.time.ZonedDateTime
-
 import com.chatwork.scala.jwk.JWKError._
 import com.chatwork.scala.jwk.utils.ECChecks
 import com.github.j5ik2o.base64scala.{ Base64EncodeError, Base64String, Base64StringFactory, BigIntUtils }
@@ -40,7 +41,7 @@ object ECJWK extends ECJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       d: Option[Base64String] = None,
       privateKey: Option[PrivateKey] = None,
       expireAt: Option[ZonedDateTime] = None,
@@ -62,7 +63,8 @@ object ECJWK extends ECJWKJsonImplicits {
           x509CertificateChain,
           d,
           privateKey,
-          expireAt
+          expireAt,
+          keyStore
         )
       )
     } catch {
@@ -82,7 +84,7 @@ object ECJWK extends ECJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       expireAt: Option[ZonedDateTime] = None
   ): Either[JWKCreationError, ECJWK] = {
     for {
@@ -155,7 +157,7 @@ class ECJWK private[jwk] (
     x509Url: Option[URI] = None,
     x509CertificateSHA1Thumbprint: Option[Base64String] = None,
     x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-    x509CertificateChain: List[Base64String] = List.empty,
+    x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
     val d: Option[Base64String] = None,
     val privateKey: Option[PrivateKey] = None,
     expireAt: Option[ZonedDateTime] = None,
@@ -357,7 +359,7 @@ trait ECJWKJsonImplicits extends JsonImplicits {
       x5u    <- hcursor.getOrElse[Option[URI]]("k5u")(None)
       k5t    <- hcursor.getOrElse[Option[Base64String]]("k5t")(None)
       k5t256 <- hcursor.getOrElse[Option[Base64String]]("k5t#256")(None)
-      k5c    <- hcursor.getOrElse[List[Base64String]]("k5c")(List.empty)
+      k5c    <- hcursor.getOrElse[Option[NonEmptyList[Base64String]]]("k5c")(None)
       crv    <- hcursor.get[Curve]("crv")
       x      <- hcursor.get[Base64String]("x")
       y      <- hcursor.get[Base64String]("y")

--- a/library/src/main/scala/com/chatwork/scala/jwk/JWK.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/JWK.scala
@@ -5,9 +5,9 @@ import cats.data.NonEmptyList
 import java.net.URI
 import java.security.KeyStore
 import java.time.ZonedDateTime
-import com.chatwork.scala.jwk.JWKError.{JOSEError, JWKThumbprintError}
+import com.chatwork.scala.jwk.JWKError.{ JOSEError, JWKThumbprintError }
 import com.github.j5ik2o.base64scala.Base64String
-import io.circe.{Decoder, Encoder}
+import io.circe.{ Decoder, Encoder }
 
 abstract class JWK(
     val keyType: KeyType,

--- a/library/src/main/scala/com/chatwork/scala/jwk/JWK.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/JWK.scala
@@ -1,12 +1,13 @@
 package com.chatwork.scala.jwk
 
+import cats.data.NonEmptyList
+
 import java.net.URI
 import java.security.KeyStore
 import java.time.ZonedDateTime
-
-import com.chatwork.scala.jwk.JWKError.{ JOSEError, JWKThumbprintError }
+import com.chatwork.scala.jwk.JWKError.{JOSEError, JWKThumbprintError}
 import com.github.j5ik2o.base64scala.Base64String
-import io.circe.{ Decoder, Encoder }
+import io.circe.{Decoder, Encoder}
 
 abstract class JWK(
     val keyType: KeyType,
@@ -17,14 +18,14 @@ abstract class JWK(
     val x509Url: Option[URI],
     val x509CertificateSHA256Thumbprint: Option[Base64String],
     val x509CertificateSHA1Thumbprint: Option[Base64String],
-    val x509CertificateChain: List[Base64String],
+    val x509CertificateChain: Option[NonEmptyList[Base64String]],
     val expireAt: Option[ZonedDateTime],
     val keyStore: Option[KeyStore]
 ) extends Ordered[JWK] {
 
   require(x509CertificateSHA256Thumbprint.fold(true)(_.urlSafe))
   require(x509CertificateSHA1Thumbprint.fold(true)(_.urlSafe))
-  require(if (x509CertificateChain.isEmpty) true else x509CertificateChain.forall(_.urlSafe))
+  require(x509CertificateChain.forall(_.forall(_.urlSafe)))
 
   require(
     publicKeyUseType.fold(true) { pku => KeyUseAndOpsConsistency.areConsistent(pku, keyOperations) },

--- a/library/src/main/scala/com/chatwork/scala/jwk/JWKThumbprint.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/JWKThumbprint.scala
@@ -11,13 +11,20 @@ import com.github.j5ik2o.base64scala.{ Base64String, Base64StringFactory }
 
 object JWKThumbprint extends JWKJsonImplicits {
 
+  // See RFC 7638 3.2
+  val requiredKeysForEC: Set[String]  = Set("crv", "kty", "x", "y")
+  val requiredKeysForRSA: Set[String] = Set("e", "kty", "n")
+
   def computeFromJWK(jwk: JWK, hashAlg: String = "SHA-256"): Either[JWKThumbprintError, Base64String] =
-    computeFromJson(jwk.asJson, hashAlg)
+    jwk.keyType match {
+      case KeyType.EC  => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForEC.contains)), hashAlg)
+      case KeyType.RSA => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForRSA.contains)), hashAlg)
+    }
 
   private def getDigest(json: Json, hashAlg: String): Either[JWKThumbprintError, Array[Byte]] = {
     try {
       val md = MessageDigest.getInstance(hashAlg)
-      md.update(json.noSpaces.getBytes(Charset.defaultCharset()))
+      md.update(json.noSpacesSortKeys.getBytes(Charset.defaultCharset()))
       Right(md.digest())
     } catch {
       case ex: NoSuchAlgorithmException =>

--- a/library/src/main/scala/com/chatwork/scala/jwk/JWKThumbprint.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/JWKThumbprint.scala
@@ -17,8 +17,9 @@ object JWKThumbprint extends JWKJsonImplicits {
 
   def computeFromJWK(jwk: JWK, hashAlg: String = "SHA-256"): Either[JWKThumbprintError, Base64String] =
     jwk.keyType match {
-      case KeyType.EC  => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForEC.contains)), hashAlg)
-      case KeyType.RSA => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForRSA.contains)), hashAlg)
+      case KeyType.EC       => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForEC.contains)), hashAlg)
+      case KeyType.RSA      => computeFromJson(jwk.asJson.mapObject(_.filterKeys(requiredKeysForRSA.contains)), hashAlg)
+      case KeyType.Other(_) => computeFromJson(jwk.asJson, hashAlg)
     }
 
   private def getDigest(json: Json, hashAlg: String): Either[JWKThumbprintError, Array[Byte]] = {

--- a/library/src/main/scala/com/chatwork/scala/jwk/RSAJWK.scala
+++ b/library/src/main/scala/com/chatwork/scala/jwk/RSAJWK.scala
@@ -1,5 +1,7 @@
 package com.chatwork.scala.jwk
 
+import cats.data.NonEmptyList
+
 import java.net.URI
 import java.security._
 import java.security.interfaces.{ RSAPrivateCrtKey, RSAPrivateKey, RSAPublicKey }
@@ -37,7 +39,7 @@ object RSAJWK extends RSAJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       d: Option[Base64String] = None,
       p: Option[Base64String] = None,
       q: Option[Base64String] = None,
@@ -87,7 +89,7 @@ object RSAJWK extends RSAJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       expireAt: Option[ZonedDateTime] = None
   ): Either[JWKCreationError, RSAJWK] = {
     for {
@@ -125,7 +127,7 @@ object RSAJWK extends RSAJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       expireAt: Option[ZonedDateTime] = None
   ): Either[JWKCreationError, RSAJWK] = {
     rsaPrivateKey match {
@@ -170,7 +172,7 @@ object RSAJWK extends RSAJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       expireAt: Option[ZonedDateTime] = None
   ): Either[JWKCreationError, RSAJWK] = {
     for {
@@ -213,7 +215,7 @@ object RSAJWK extends RSAJWKJsonImplicits {
       x509Url: Option[URI] = None,
       x509CertificateSHA1Thumbprint: Option[Base64String] = None,
       x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-      x509CertificateChain: List[Base64String] = List.empty,
+      x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
       expireAt: Option[ZonedDateTime] = None
   ): Either[JWKCreationError, RSAJWK] = {
     for {
@@ -283,7 +285,7 @@ class RSAJWK private[jwk] (
     x509Url: Option[URI] = None,
     x509CertificateSHA1Thumbprint: Option[Base64String] = None,
     x509CertificateSHA256Thumbprint: Option[Base64String] = None,
-    x509CertificateChain: List[Base64String] = List.empty,
+    x509CertificateChain: Option[NonEmptyList[Base64String]] = None,
     d: Option[Base64String] = None,
     p: Option[Base64String] = None,
     q: Option[Base64String] = None,
@@ -643,7 +645,7 @@ trait RSAJWKJsonImplicits extends JsonImplicits {
       x5u    <- hcursor.getOrElse[Option[URI]]("k5u")(None)
       k5t    <- hcursor.getOrElse[Option[Base64String]]("k5t")(None)
       k5t256 <- hcursor.getOrElse[Option[Base64String]]("k5t#256")(None)
-      k5c    <- hcursor.getOrElse[List[Base64String]]("k5c")(List.empty)
+      k5c    <- hcursor.getOrElse[Option[NonEmptyList[Base64String]]]("k5c")(None)
       n      <- hcursor.get[Base64String]("n")
       e      <- hcursor.get[Base64String]("e")
       d      <- hcursor.getOrElse[Option[Base64String]]("d")(None)

--- a/library/src/test/scala/com/chatwork/scala/jwk/ECJWKSpec.scala
+++ b/library/src/test/scala/com/chatwork/scala/jwk/ECJWKSpec.scala
@@ -51,15 +51,15 @@ class ECJWKSpec extends AnyFreeSpec with Matchers with ECJWKJsonImplicits with E
     "unknown Curve" in {
       val jwk = ECJWK(Curve("unknown", None, None), P_256.x, P_256.y)
       jwk match {
-        case Left(e: JWKCreationError) =>
-          println(e.message)
+        case Left(_: JWKCreationError) =>
+          succeed
         case Left(_) =>
           fail()
         case Right(_) =>
           fail()
       }
     }
-    "testJose4jVectorP256" in {
+    "testP256" in {
       val json = "{\"kty\":\"EC\"," +
         "\"x\":\"CEuRLUISufhcjrj-32N0Bvl3KPMiHH9iSw4ohN9jxrA\"," +
         "\"y\":\"EldWz_iXSK3l_S7n4w_t3baxos7o9yqX0IjzG959vHc\"," +
@@ -68,9 +68,9 @@ class ECJWKSpec extends AnyFreeSpec with Matchers with ECJWKJsonImplicits with E
       jwk.keyType shouldBe KeyType.EC
       jwk.curve shouldBe Curve.P_256
       val result = jwk.computeThumbprint.value
-      result.asString shouldBe "W6b8Mt2xhDFiy8sJe-MoWXIIkbty0HDhRjfI3VYWH6s"
+      result.asString shouldBe "j4UYwo9wrtllSHaoLDJNh7MhVCL8t0t8cGPPzChpYDs"
     }
-    "testJose4jVectorP384" in {
+    "testP384" in {
       val json = "{\"kty\":\"EC\"," +
         " \"x\":\"2jCG5DmKUql9YPn7F2C-0ljWEbj8O8-vn5Ih1k7Wzb-y3NpBLiG1BiRa392b1kcQ\"," +
         " \"y\":\"7Ragi9rT-5tSzaMbJlH_EIJl6rNFfj4V4RyFM5U2z4j1hesX5JXa8dWOsE-5wPIl\"," +
@@ -79,9 +79,9 @@ class ECJWKSpec extends AnyFreeSpec with Matchers with ECJWKJsonImplicits with E
       jwk.keyType shouldBe KeyType.EC
       jwk.curve shouldBe Curve.P_384
       val result = jwk.computeThumbprint.value
-      result.asString shouldBe "S-6tPnrLPensd2med1er_jX_j7mythdvKIj9O_sNqL0"
+      result.asString shouldBe "vZtaWIw-zw95JNzzURg1YB7mWNLlm44YZDZzhrPNetM"
     }
-    "testJose4jVectorP521" in {
+    "testP521" in {
       val json = "{\"kty\":\"EC\"," +
         "\"x\":\"Aeq3uMrb3iCQEt0PzSeZMmrmYhsKP5DM1oMP6LQzTFQY9-F3Ab45xiK4AJxltXEI-87g3gRwId88hTyHgq180JDt\"," +
         "\"y\":\"ARA0lIlrZMEzaXyXE4hjEkc50y_JON3qL7HSae9VuWpOv_2kit8p3pyJBiRb468_U5ztLT7FvDvtimyS42trhDTu\"," +
@@ -90,7 +90,7 @@ class ECJWKSpec extends AnyFreeSpec with Matchers with ECJWKJsonImplicits with E
       jwk.keyType shouldBe KeyType.EC
       jwk.curve shouldBe Curve.P_521
       val result = jwk.computeThumbprint.value
-      result.asString shouldBe "EroitZ-og3Ji6ENuMuey6vEz4hA2i56rOJHfrTeDHII"
+      result.asString shouldBe "rz4Ohmpxg-UOWIWqWKHlOe0bHSjNUFlHW5vwG_M7qYg"
     }
   }
 }

--- a/library/src/test/scala/com/chatwork/scala/jwk/JWKSetSpec.scala
+++ b/library/src/test/scala/com/chatwork/scala/jwk/JWKSetSpec.scala
@@ -133,8 +133,7 @@ class JWKSetSpec extends AnyFreeSpec with Matchers with JWKSetJsonImplicits {
           )
         )
       )
-      jwkSet.getOrElse(???) shouldBe JWKSet(rsaJwk("1"), rsaJwk("2"))
-      println(jwkSet)
+      jwkSet shouldBe Right(JWKSet(rsaJwk("1"), rsaJwk("2")))
     }
   }
 }

--- a/library/src/test/scala/com/chatwork/scala/jwk/KeyIdSpec.scala
+++ b/library/src/test/scala/com/chatwork/scala/jwk/KeyIdSpec.scala
@@ -29,8 +29,7 @@ class KeyIdSpec extends AnyFreeSpec with Matchers {
     "should be able to create from RSA PublicKey params" in {
       val result =
         KeyId.fromRSAPublicKeyParams(Base64String(n, urlSafe = true), Base64String(e, urlSafe = true))
-      println(result)
-      result shouldBe Right(KeyId("zxHHCn6NUeqNxYOKWGV8kyUkgPOuwpIIF8_Fj0aaIIo"))
+      result shouldBe Right(KeyId("NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"))
     }
     "should be able to create from RSA PublicKey" in {
       val keyId = for {
@@ -42,7 +41,7 @@ class KeyIdSpec extends AnyFreeSpec with Matchers {
           KeyId.fromRSAPublicKey(factory.generatePublic(keySpec).asInstanceOf[RSAPublicKey])
         }
       } yield result
-      keyId shouldBe Right(KeyId("zxHHCn6NUeqNxYOKWGV8kyUkgPOuwpIIF8_Fj0aaIIo"))
+      keyId shouldBe Right(KeyId("NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"))
     }
   }
 }

--- a/library/src/test/scala/com/chatwork/scala/jwk/RSAJWKSpec.scala
+++ b/library/src/test/scala/com/chatwork/scala/jwk/RSAJWKSpec.scala
@@ -1,17 +1,18 @@
 package com.chatwork.scala.jwk
 
+import cats.data.NonEmptyList
+
 import java.net.URI
 import java.security.interfaces.{ RSAPrivateCrtKey, RSAPrivateKey, RSAPublicKey }
 import java.security.spec.RSAPrivateKeySpec
 import java.security.{ KeyFactory, KeyPairGenerator }
-
 import com.github.j5ik2o.base64scala.{ Base64String, Base64StringFactory }
 import io.circe.parser._
-import io.circe.syntax._
+import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
 
-class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
+class RSAJWKSpec extends AnyFreeSpec with Matchers with OptionValues with RSAJWKJsonImplicits {
   val base64StringFactory = Base64StringFactory(urlSafe = true, isNoPadding = true)
   private val n = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx" +
     "4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs" +
@@ -54,7 +55,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
       val x5u    = new URI("http://example.com/jwk.json")
       val x5t    = Base64String("abc", urlSafe = true)
       val x5t256 = Base64String("abc256", urlSafe = true)
-      val x5c    = List(Base64String("def", urlSafe = true))
+      val x5c    = NonEmptyList.one(Base64String("def", urlSafe = true))
 
       val factory = KeyFactory.getInstance("RSA")
       val privateKey = for {
@@ -76,7 +77,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         x509Url = Some(x5u),
         x509CertificateSHA1Thumbprint = Some(x5t),
         x509CertificateSHA256Thumbprint = Some(x5t256),
-        x509CertificateChain = x5c,
+        x509CertificateChain = Some(x5c),
         d = Some(Base64String(d, urlSafe = true)),
         p = Some(Base64String(p, urlSafe = true)),
         q = Some(Base64String(q, urlSafe = true)),
@@ -93,8 +94,8 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
       key.x509Url shouldBe Some(x5u)
       key.x509CertificateSHA1Thumbprint shouldBe Some(x5t)
       key.x509CertificateSHA256Thumbprint shouldBe Some(x5t256)
-      key.x509CertificateChain shouldBe x5c
-      key.x509CertificateChain.length shouldBe x5c.length
+      key.x509CertificateChain shouldBe Some(x5c)
+      key.x509CertificateChain.value.length shouldBe x5c.length
 
       key.modulus shouldBe Base64String(n, urlSafe = true)
       key.publicExponent shouldBe Base64String(e, urlSafe = true)
@@ -109,8 +110,6 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
 
       key.firstCRTCoefficient shouldBe Some(Base64String(qi, urlSafe = true))
 
-      println(key.asJson.spaces2)
-
       key.isPrivate shouldBe true
 
       val publicKey = key.toPublicJWK
@@ -121,8 +120,8 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
       publicKey.x509Url shouldBe Some(x5u)
       publicKey.x509CertificateSHA1Thumbprint shouldBe Some(x5t)
       publicKey.x509CertificateSHA256Thumbprint shouldBe Some(x5t256)
-      publicKey.x509CertificateChain shouldBe x5c
-      publicKey.x509CertificateChain.length shouldBe x5c.length
+      publicKey.x509CertificateChain shouldBe Some(x5c)
+      publicKey.x509CertificateChain.value.length shouldBe x5c.length
 
       publicKey.modulus shouldBe Base64String(n, urlSafe = true)
       publicKey.publicExponent shouldBe Base64String(e, urlSafe = true)
@@ -164,7 +163,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         x509Url = None,
         x509CertificateSHA1Thumbprint = None,
         x509CertificateSHA256Thumbprint = None,
-        x509CertificateChain = List.empty,
+        x509CertificateChain = None,
         d = Some(Base64String(d, urlSafe = true)),
         p = Some(Base64String(p, urlSafe = true)),
         q = Some(Base64String(q, urlSafe = true)),
@@ -229,7 +228,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         x509Url = None,
         x509CertificateSHA1Thumbprint = None,
         x509CertificateSHA256Thumbprint = None,
-        x509CertificateChain = List.empty
+        x509CertificateChain = None
       )
 
       key2.map(_.publicKeyUseType) shouldBe Right(Some(PublicKeyUseType.Signature))
@@ -263,7 +262,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         x509Url = None,
         x509CertificateSHA1Thumbprint = None,
         x509CertificateSHA256Thumbprint = None,
-        x509CertificateChain = List.empty
+        x509CertificateChain = None
       )
 
       key3.map(_.publicKeyUseType) shouldBe Right(Some(PublicKeyUseType.Signature))
@@ -309,7 +308,7 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         x509Url = None,
         x509CertificateSHA1Thumbprint = None,
         x509CertificateSHA256Thumbprint = None,
-        x509CertificateChain = List.empty,
+        x509CertificateChain = None,
         d = Some(Base64String(d, urlSafe = true)),
         p = Some(Base64String(p, urlSafe = true)),
         q = Some(Base64String(q, urlSafe = true)),
@@ -677,8 +676,8 @@ class RSAJWKSpec extends AnyFreeSpec with Matchers with RSAJWKJsonImplicits {
         "BniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\"}"
       val jwk        = parse(jsonText).flatMap { json => json.as[RSAJWK] }
       val thumbprint = jwk.flatMap(_.computeThumbprint)
-      println(thumbprint)
       thumbprint shouldBe jwk.flatMap(_.computeThumbprint("SHA-256"))
+      thumbprint shouldBe Right(Base64String("NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"))
     }
 
   }


### PR DESCRIPTION
According to the [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517#section-4.7), the `x5c` field of a JWK must be non-empty, hence this converts it from `List` to `Option[NonEmptyList]`. This broke unexpectedly the tests for thumbprinting as it didn't align with the [RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638#section-3.2), so the thumbprinting got fixed as well, now taking only required fields into concern as the RFC states.

More comments inline.

As this is a binary breaking change, I suggest to release it as a new major version.